### PR TITLE
[fix] Modify the htaccess marker

### DIFF
--- a/epfl-intranet.php
+++ b/epfl-intranet.php
@@ -296,7 +296,7 @@ class Settings extends \EPFL\SettingsBase
         have to remove 'wp-content' '*/
         $filename = str_replace("wp-content", ".htaccess", WP_CONTENT_DIR);
 
-        $marker = 'EPFL-Intranet';
+        $marker = 'ANSIBLE MANAGED BLOCK FOR EPFL-Intranet';
 
         return insert_with_markers($filename, $marker, $insertion);
 


### PR DESCRIPTION
Pour donner suite à cette [PR](https://github.com/epfl-si/wp-ops/pull/276) on modifie le marker dans plugin pour éviter que le bloc dans le fichier .htaccess ne soit créé 2 fois.
