### PR TITLE
Protection activated if plugin activated

### DIFF
--- a/inc/protect-medias.php
+++ b/inc/protect-medias.php
@@ -1,7 +1,15 @@
 <?PHP
     require_once(dirname($_SERVER["SCRIPT_FILENAME"], 5) . '/wp-load.php');
 
-    if (!is_user_logged_in())
+
+    
+
+    /* We redirect on login page only if plugin is active. Otherwise there's no protection.
+    Normally, if plugin is deactivated, RewriteRule in .htaccess file redirection on present file
+    is not present, so, checking plugin activation is useless. But, we do this in case of an
+    inconsistency somewhere in the Matrix! */
+    $epfl_intranet_plugin_full_path = dirname(__FILE__). '/../epfl-intranet.php';
+    if (is_plugin_active($epfl_intranet_plugin_full_path) && !is_user_logged_in())
     {
        $upload_dir = wp_upload_dir();
        wp_redirect( wp_login_url( $upload_dir['baseurl'] . '/' . $_GET[ 'file' ]));


### PR DESCRIPTION
- Activation de la protection uniquement si le plugin est activé
- Ajout de hooks pour l'activation et la désactivation afin de contrôler les prérequis (activation seulement) et mettre à jour le fichier `.htaccess` pour la protection des fichiers
- Changement des commandes WP-CLI pour:
   - Virer `wp epfl intranet disable-protection` (c'est maintenant `wp plugin deactivate epfl-intranet` qui va faire le taff)
   - Renommer `wp epfl intranet enable-protection` en `wp epfl intranet update-protection` 
   - Mise à jour des commandes dans `wp-ops` pour que ça colle à la nouvelle manière de fonctionner du plugin (https://github.com/epfl-si/wp-ops/pull/289)
- Ajout d'un check dans la protection des médias pour voir si le plugin est activé ou pas. Normalement, si la règle de redirection du `.htaccess` est présente, c'est que le plugin est activé mais on check quand même.
- Erreur levée (`die`) dans le cas où un prérequis ne serait pas rempli ou si on ne peut pas écrire dans le `.htaccess`. ça s'affiche en texte si appelée en WP-CLI et ça affiche un message dans le GUI si c'est depuis là qu'on fait le truc (c'est moche oui, mais ça fait le taff)
![image](https://user-images.githubusercontent.com/11942430/86760118-47512c80-c045-11ea-8f11-6b9094584732.png)
