### PR TITLE
Fix media protection

### DIFF
--- a/epfl-intranet.php
+++ b/epfl-intranet.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Intranet
  * Description: Use EPFL Accred to allow website access only to specific group(s) or just force to be authenticated
- * Version:     0.19
+ * Version:     0.20
  * Author:      Lucien Chaboudez
  * Author URI:  mailto:lucien.chaboudez@epfl.ch
  */

--- a/inc/protect-medias.php
+++ b/inc/protect-medias.php
@@ -8,7 +8,7 @@
     Normally, if plugin is deactivated, RewriteRule in .htaccess file redirection on present file
     is not present, so, checking plugin activation is useless. But, we do this in case of an
     inconsistency somewhere in the Matrix! */
-    $epfl_intranet_plugin_full_path = dirname(__FILE__). '/../epfl-intranet.php';
+    $epfl_intranet_plugin_full_path = 'epfl-intranet/epfl-intranet.php';
     if (is_plugin_active($epfl_intranet_plugin_full_path) && !is_user_logged_in())
     {
        $upload_dir = wp_upload_dir();


### PR DESCRIPTION
Correction d'un bug qui faisait qu'on ne détectait pas que le plugin était activé et donc les médias n'étaient pas protégés... c'était le chemin complet jusqu'au fichier du plugin qui était passé à la fonction `is_plugin_active` alors qu'il fallait passer le chemin relatif au dossier `wp-content/plugins/`, tout simplement 🤦‍♂️ 