### PR TITLE
[fix] Media with query string

### DIFF
--- a/epfl-intranet.php
+++ b/epfl-intranet.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Intranet
  * Description: Use EPFL Accred to allow website access only to specific group(s) or just force to be authenticated
- * Version:     1.1.0
+ * Version:     1.2.0
  * Author:      EPFL SI
  */
 

--- a/inc/protect-medias.php
+++ b/inc/protect-medias.php
@@ -12,7 +12,8 @@
     }
 
     list($basedir) = array_values(array_intersect_key(wp_upload_dir(), array('basedir' => 1)))+array(NULL);
-    $file = str_replace($_SERVER["WP_ROOT_URI"] . 'wp-content/uploads', $upload_dir["basedir"], urldecode($_SERVER['REQUEST_URI']));
+    $url_path_without_query_string = parse_url( urldecode( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH );
+    $file = str_replace( $_SERVER['WP_ROOT_URI'] . 'wp-content/uploads', $upload_dir['basedir'], $url_path_without_query_string );
     if ( (strpos($file, "/../") !== FALSE) ||
          (strpos($file, "../") === 0) )
     {


### PR DESCRIPTION
Whenever search for the corresponding path from the URL, one must remove the query string in order to actually find the file. See the incident INC0707789 that raised the issue.